### PR TITLE
Added Arch Linux compile instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,10 +26,20 @@ It is completely cross platform, and runs on Linux (using libusb), OS X (native 
 
 ##### Linux
  - Requires libusb
+ - Requires a [udev rule for libusb](https://www.themooltipass.com/udev_rule.txt)
 
 ##### Ubuntu 16.04
 ```bash
 sudo apt-get install libqt5websockets5-dev libusb-dev libusb-1.0-0-dev qt-sdk qt5-qmake qt5-default
+echo "ATTRS{idVendor}==\"16d0\", ATTRS{idProduct}==\"09a0\", SYMLINK+=\"mooltipass\", MODE=\"0664\", GROUP=\"plugdev\"" | sudo tee /etc/udev/rules.d/50-mooltipass.rules
+sudo udevadm control --reload-rules
+```
+
+##### Arch Linux
+```bash
+sudo pacman -S --needed qt5-websockets libusb qt5-base
+echo 'SUBSYSTEM=="usb", ATTRS{idVendor}=="16d0", ATTRS{idProduct}=="09a0", TAG+="uaccess"' | sudo tee /etc/udev/rules.d/50-mooltipass.rules
+sudo udevadm control --reload-rules
 ```
 
 ### How to build


### PR DESCRIPTION
@raoulh I can compile moolticuted with those instructions on my raspi3 and start the app. However I still have no access to the device. I tried to run chromium with the official app that works. I used the special archlinux udev rule that is suggested in the official textfile. So there must be something still wrong in the udev rule I guess. Do you have any idea?