### PR TITLE
Removing XCB dependencies from daemon on Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Packages are build and available here: https://calaos.fr/mooltipass/
 
 ##### Ubuntu 16.04
 ```bash
-sudo apt-get install libqt5websockets5-dev libusb-dev libusb-1.0-0-dev qt-sdk qt5-qmake qt5-default
+sudo apt install libqt5websockets5-dev libusb-dev libusb-1.0-0-dev qt-sdk qt5-qmake qt5-default
 echo 'SUBSYSTEM=="usb", ATTRS{idVendor}=="16d0", ATTRS{idProduct}=="09a0", TAG+="uaccess"' | sudo tee /etc/udev/rules.d/50-mooltipass.rules
 sudo udevadm control --reload-rules
 ```

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Packages are build and available here: https://calaos.fr/mooltipass/
 ##### Ubuntu 16.04
 ```bash
 sudo apt-get install libqt5websockets5-dev libusb-dev libusb-1.0-0-dev qt-sdk qt5-qmake qt5-default
-echo "ATTRS{idVendor}==\"16d0\", ATTRS{idProduct}==\"09a0\", SYMLINK+=\"mooltipass\", MODE=\"0664\", GROUP=\"plugdev\"" | sudo tee /etc/udev/rules.d/50-mooltipass.rules
+echo 'SUBSYSTEM=="usb", ATTRS{idVendor}=="16d0", ATTRS{idProduct}=="09a0", TAG+="uaccess"' | sudo tee /etc/udev/rules.d/50-mooltipass.rules
 sudo udevadm control --reload-rules
 ```
 

--- a/daemon.pro
+++ b/daemon.pro
@@ -118,4 +118,9 @@ unix {
     # install the binary
     target.path = $$PREFIX/bin
     INSTALLS += target
+
+    # systemd service files
+    systemd_user.path = $$PREFIX/lib/systemd/user/
+    systemd_user.files += $$PWD/systemd/moolticuted.service
+    INSTALLS += systemd_user
 }

--- a/daemon.pro
+++ b/daemon.pro
@@ -17,6 +17,7 @@ win32 {
     QT_CONFIG -= no-pkg-config
     CONFIG += link_pkgconfig
     PKGCONFIG += libusb-1.0
+    QT -= widgets
 } else:mac {
     LIBS += -framework ApplicationServices -framework IOKit -framework CoreFoundation -framework Cocoa -framework Foundation
 }

--- a/daemon.pro
+++ b/daemon.pro
@@ -124,4 +124,9 @@ unix {
     systemd_user.path = $$PREFIX/lib/systemd/user/
     systemd_user.files += $$PWD/systemd/moolticuted.service
     INSTALLS += systemd_user
+
+    # udev rules
+    udev_rules.path = $$PREFIX/lib/udev/rules.d/
+    udev_rules.files += $$PWD/udev/69-mooltipass.rules
+    INSTALLS += udev_rules
 }

--- a/src/AppDaemon.cpp
+++ b/src/AppDaemon.cpp
@@ -28,7 +28,11 @@
 bool g_bEmulationMode = false;
 
 AppDaemon::AppDaemon(int &argc, char **argv):
+#ifdef Q_OS_LINUX
+    QCoreApplication(argc, argv),
+#else
     QApplication(argc, argv),
+#endif
     sharedMem("moolticute")
 {
 }
@@ -100,7 +104,7 @@ bool AppDaemon::initialize()
                                        QCoreApplication::translate("main", "port"));
     parser.addOption(debugHttpServer);
 
-    parser.process(QApplication::arguments());
+    parser.process(QAPP::arguments());
 
     g_bEmulationMode = parser.isSet(emulationMode);
 

--- a/src/AppDaemon.h
+++ b/src/AppDaemon.h
@@ -19,7 +19,13 @@
 #ifndef APPDAEMON_H
 #define APPDAEMON_H
 
+#if defined(Q_OS_MAC) || defined(Q_OS_WIN)
 #include <QApplication>
+#define QAPP QApplication
+#else
+#include <QCoreApplication>
+#define QAPP QCoreApplication
+#endif
 #include <QObject>
 #include <QSettings>
 #include <QLocalServer>
@@ -31,7 +37,7 @@
 
 extern bool g_bEmulationMode;
 
-class AppDaemon: public QApplication
+class AppDaemon: public QAPP
 {
     Q_OBJECT
 public:

--- a/src/HttpClient.cpp
+++ b/src/HttpClient.cpp
@@ -1,5 +1,5 @@
 #include <QFile>
-#include <QImage>
+/* #include <QImage> */
 #include "HttpClient.h"
 #include <QDir>
 

--- a/systemd/moolticuted.service
+++ b/systemd/moolticuted.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Moolticute daemon
+
+[Service]
+ExecStart=/usr/bin/moolticuted
+KillMode=process
+Restart=always
+Type=simple
+
+[Install]
+WantedBy=multi-user.target

--- a/udev/69-mooltipass.rules
+++ b/udev/69-mooltipass.rules
@@ -1,0 +1,9 @@
+# udev rules for allowing console user(s) and libusb access to Mooltipass Mini devices
+ACTION!="add|change", GOTO="mooltipass_end"
+
+# console user
+KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="16d0", ATTRS{idProduct}=="09a0", MODE="0660", TAG+="uaccess"
+# libusb
+SUBSYSTEM=="usb", ATTRS{idVendor}=="16d0", ATTRS{idProduct}=="09a0", MODE="0660", TAG+="uaccess"
+
+LABEL="mooltipass_end"


### PR DESCRIPTION
The main work is related to removing the dependencies on XCB for the daemon on Linux.
I get in trouble when removing the widget QT modules by not beeing able to compile in some case so I change the:

```
#if defined(Q_OS_LINUX)
// ...
#else
//
#endif
```

into

```
#if defined(Q_OS_WIN) || defined(Q_OS_MAC)
// ..
#else
// ...
#endif
```

When this dependencies is removed one can integrate upstream a systemd service for running the daemon easily.

I also merge udev rules provided for Arch and ubuntu and think that it would works on every systemd based host.