### PR TITLE
Dev/systemd: Move the systemd service file systemd wide

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Packages are build and available here: https://calaos.fr/mooltipass/
 
 ##### Linux
  - Requires libusb
- - Requires a [udev rule for libusb](https://www.themooltipass.com/udev_rule.txt)
+ - Requires a [udev rule for libusb](https://github.com/bobsaintcool/mooltipass-udev)
 
 ##### Ubuntu 16.04
 ```bash

--- a/daemon.pro
+++ b/daemon.pro
@@ -121,7 +121,7 @@ unix {
     INSTALLS += target
 
     # systemd service files
-    systemd_user.path = $$PREFIX/lib/systemd/user/
+    systemd_user.path = $$PREFIX/lib/systemd/system/
     systemd_user.files += $$PWD/systemd/moolticuted.service
     INSTALLS += systemd_user
 }

--- a/daemon.pro
+++ b/daemon.pro
@@ -124,9 +124,4 @@ unix {
     systemd_user.path = $$PREFIX/lib/systemd/user/
     systemd_user.files += $$PWD/systemd/moolticuted.service
     INSTALLS += systemd_user
-
-    # udev rules
-    udev_rules.path = $$PREFIX/lib/udev/rules.d/
-    udev_rules.files += $$PWD/udev/69-mooltipass.rules
-    INSTALLS += udev_rules
 }

--- a/udev/69-mooltipass.rules
+++ b/udev/69-mooltipass.rules
@@ -1,9 +1,0 @@
-# udev rules for allowing console user(s) and libusb access to Mooltipass Mini devices
-ACTION!="add|change", GOTO="mooltipass_end"
-
-# console user
-KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="16d0", ATTRS{idProduct}=="09a0", MODE="0660", TAG+="uaccess"
-# libusb
-SUBSYSTEM=="usb", ATTRS{idVendor}=="16d0", ATTRS{idProduct}=="09a0", MODE="0660", TAG+="uaccess"
-
-LABEL="mooltipass_end"


### PR DESCRIPTION
Only one instance of moolticute could be run at a time. It makes more
sense to move the systemd service file systemd wide.