### PR TITLE
Fix tab stop order in credentials management window

### DIFF
--- a/src/CredentialsManagement.ui
+++ b/src/CredentialsManagement.ui
@@ -648,6 +648,23 @@ padding: 2px;
    <header>PasswordLineEdit.h</header>
   </customwidget>
  </customwidgets>
+ <tabstops>
+  <tabstop>addCredServiceInput</tabstop>
+  <tabstop>addCredLoginInput</tabstop>
+  <tabstop>addCredPasswordInput</tabstop>
+  <tabstop>addCredentialButton</tabstop>
+  <tabstop>pushButtonEnterMMM</tabstop>
+  <tabstop>lineEditFilterCred</tabstop>
+  <tabstop>credentialsListView</tabstop>
+  <tabstop>credDisplayServiceInput</tabstop>
+  <tabstop>credDisplayLoginInput</tabstop>
+  <tabstop>credDisplayPasswordInput</tabstop>
+  <tabstop>credDisplayDescriptionInput</tabstop>
+  <tabstop>credDisplayCreationDateInput</tabstop>
+  <tabstop>credDisplayModificationDateInput</tabstop>
+  <tabstop>buttonSaveChanges</tabstop>
+  <tabstop>buttonDiscard</tabstop>
+ </tabstops>
  <resources>
   <include location="../img/images.qrc"/>
  </resources>


### PR DESCRIPTION
The credentials management window had an odd order for advancing between widgets using the ``tab`` key.