### PR TITLE
Implemented:

### DIFF
--- a/src/MainWindow.h
+++ b/src/MainWindow.h
@@ -81,7 +81,9 @@ private slots:
     void on_pushButtonSettingsReset_clicked();
     void on_pushButtonSettingsSave_clicked();
 
-    void onKeyboardShortcutActivated();
+    void onFilesAndSSHTabsShortcutActivated();
+    void onAdvancedTabShortcutActivated();
+    void onRadioButtonFilesAndSSHKeysTabsAlwaysVisibleToggled(bool bChecked);
 
 private:
     void setUIDRequestInstructionsWithId(const QString &id = "XXXX");
@@ -89,6 +91,8 @@ private:
     virtual void closeEvent(QCloseEvent *event);
 
     void checkAutoStart();
+
+    void setFilesAndSSHKeysTabsVisibleOnDemand(bool bValue, bool bUpdateAdvancedTabVisibility=false);
 
     Ui::MainWindow *ui;
     QtAwesome* awesome;
@@ -102,6 +106,11 @@ private:
 
     QShortcut *keyboardShortcut;
     bool bFilesAndSSHKeyTabsVisible;
+    bool bAdvancedTabVisible;
+    bool bFilesAndSSHKeysTabsVisibleOnDemand;
+
+    QShortcut *m_FilesAndSSHKeysTabsShortcut;
+    QShortcut *m_advancedTabShortcut;
 };
 
 #endif // MAINWINDOW_H

--- a/src/MainWindow.ui
+++ b/src/MainWindow.ui
@@ -2195,7 +2195,7 @@ QWidget {background-color: #EFEFEF;}</string>
         <item row="1" column="0">
          <widget class="QRadioButton" name="radioButtonTabsAndSSHKeyTabsVisibleOnDemand">
           <property name="text">
-           <string>Files and SSH Keys tabs visible ON DEMAND (use CTRL+SHIFT+F2 keyboard shortcut)</string>
+           <string>Files and SSH Keys tabs visible ON DEMAND (use CTRL+SHIFT+F1 keyboard shortcut)</string>
           </property>
          </widget>
         </item>

--- a/src/MainWindow.ui
+++ b/src/MainWindow.ui
@@ -195,6 +195,19 @@ QWidget {background-color: #EFEFEF;}</string>
         </widget>
        </item>
        <item>
+        <widget class="QPushButton" name="pushButtonAdvanced">
+         <property name="text">
+          <string>Advanced</string>
+         </property>
+         <property name="checkable">
+          <bool>true</bool>
+         </property>
+         <property name="autoExclusive">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item>
         <widget class="QPushButton" name="pushButtonAbout">
          <property name="text">
           <string>About</string>
@@ -225,7 +238,7 @@ QWidget {background-color: #EFEFEF;}</string>
        <enum>Qt::LeftToRight</enum>
       </property>
       <property name="currentIndex">
-       <number>2</number>
+       <number>13</number>
       </property>
       <widget class="QWidget" name="pageNoDaemon">
        <layout class="QHBoxLayout" name="horizontalLayout_noDaemon1">
@@ -2167,6 +2180,24 @@ QWidget {background-color: #EFEFEF;}</string>
         </property>
         <item>
          <widget class="SSHManagement" name="widgetSSH" native="true"/>
+        </item>
+       </layout>
+      </widget>
+      <widget class="QWidget" name="pageAdvanced">
+       <layout class="QGridLayout" name="gridLayout">
+        <item row="0" column="0">
+         <widget class="QRadioButton" name="radioButtonFilesAndSSHKeysTabsAlwaysVisible">
+          <property name="text">
+           <string>Files and SSH Keys tabs ALWAYS visible</string>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="0">
+         <widget class="QRadioButton" name="radioButtonTabsAndSSHKeyTabsVisibleOnDemand">
+          <property name="text">
+           <string>Files and SSH Keys tabs visible ON DEMAND (use CTRL+SHIFT+F2 keyboard shortcut)</string>
+          </property>
+         </widget>
         </item>
        </layout>
       </widget>


### PR DESCRIPTION
- ajouter un racourci clavier (du type ctrl-a-d-v) pour activer une nouvelle tab (à créer) intitulée "Advanced"
- dans cette nouvelle tab "Advanced" ajouter une option pour laisser activé les tabs "Files" et "SSH Keys" sans racourci clavier
Le raisonnement derrière ces changements: la plupart des utilisateurs ont une utilisation basique du mooltipass. Nous aimerions ainsi éviter de réaliser trop de support une fois que ceux ci commencent à toucher à ces tabs la. De plus, nous n'avons pas encore terminé le travail sur ces tabs.
