### PR TITLE
Combine device information labels at one widget

### DIFF
--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -421,6 +421,7 @@ MainWindow::MainWindow(WSClient *client, QWidget *parent) :
     ui->scrollArea->setStyleSheet("QScrollArea { background-color:transparent; }");
     ui->scrollAreaWidgetContents->setStyleSheet("#scrollAreaWidgetContents { background-color:transparent; }");
 
+    updateSerialInfos();
     updatePage();
 }
 
@@ -540,14 +541,22 @@ void MainWindow::enableKnockSettings(bool enable)
 }
 
 void MainWindow::updateSerialInfos() {
-    ui->labelAbouHwSerial->setText(tr("Device Serial: %1").arg(wsClient->get_hwSerial()));
-    ui->labelAboutFwVers->setText(tr("Device Firmware version: %1").arg(wsClient->get_fwVersion()));
-
     const bool connected = wsClient->get_connected();
 
-    ui->labelAboutFwVers->setVisible(connected);
-    ui->labelAbouHwSerial->setVisible(connected && wsClient->get_hwSerial() > 0);
-    ui->labelAbouHwMemory->setText(tr("Device Serial: %1Mb").arg(wsClient->get_hwMemory()));
+    ui->deviceInfoWidget->setVisible(connected);
+
+    if(connected)
+    {
+        ui->labelAboutFwVersValue->setText(wsClient->get_fwVersion());
+        ui->labelAbouHwSerialValue->setText(wsClient->get_hwSerial() > 0 ? QString::number(wsClient->get_hwSerial()) : tr("None"));
+        ui->labelAbouHwMemoryValue->setText(tr("%1Mb").arg(wsClient->get_hwMemory()));
+    }
+    else
+    {
+        ui->labelAboutFwVersValue->setText(tr("None"));
+        ui->labelAbouHwSerialValue->setText(tr("None"));
+        ui->labelAbouHwMemoryValue->setText(tr("None"));
+    }
 }
 
 void MainWindow::checkSettingsChanged()

--- a/src/MainWindow.ui
+++ b/src/MainWindow.ui
@@ -1743,39 +1743,123 @@ QWidget {background-color: #EFEFEF;}</string>
          </widget>
         </item>
         <item>
-         <widget class="QLabel" name="labelAboutFwVers">
-          <property name="font">
-           <font>
-            <pointsize>10</pointsize>
-           </font>
-          </property>
-          <property name="text">
-           <string>Device Firmware version: %1</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QLabel" name="labelAbouHwSerial">
-          <property name="font">
-           <font>
-            <pointsize>10</pointsize>
-           </font>
-          </property>
-          <property name="text">
-           <string>Device Serial: %1</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QLabel" name="labelAbouHwMemory">
-          <property name="font">
-           <font>
-            <pointsize>10</pointsize>
-           </font>
-          </property>
-          <property name="text">
-           <string>Device Memory: %1</string>
-          </property>
+         <widget class="QWidget" name="deviceInfoWidget" native="true">
+          <layout class="QVBoxLayout" name="verticalLayout_23">
+           <property name="leftMargin">
+            <number>0</number>
+           </property>
+           <property name="topMargin">
+            <number>0</number>
+           </property>
+           <property name="rightMargin">
+            <number>0</number>
+           </property>
+           <property name="bottomMargin">
+            <number>0</number>
+           </property>
+           <item>
+            <layout class="QHBoxLayout" name="horizontalLayout_13">
+             <item>
+              <widget class="QLabel" name="labelAboutFwVers">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="font">
+                <font>
+                 <pointsize>10</pointsize>
+                </font>
+               </property>
+               <property name="text">
+                <string>Device Firmware version:</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QLabel" name="labelAboutFwVersValue">
+               <property name="font">
+                <font>
+                 <pointsize>10</pointsize>
+                </font>
+               </property>
+               <property name="text">
+                <string/>
+               </property>
+              </widget>
+             </item>
+            </layout>
+           </item>
+           <item>
+            <layout class="QHBoxLayout" name="horizontalLayout_15">
+             <item>
+              <widget class="QLabel" name="labelAbouHwSerial">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="font">
+                <font>
+                 <pointsize>10</pointsize>
+                </font>
+               </property>
+               <property name="text">
+                <string>Device Serial:</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QLabel" name="labelAbouHwSerialValue">
+               <property name="font">
+                <font>
+                 <pointsize>10</pointsize>
+                </font>
+               </property>
+               <property name="text">
+                <string/>
+               </property>
+              </widget>
+             </item>
+            </layout>
+           </item>
+           <item>
+            <layout class="QHBoxLayout" name="horizontalLayout_29">
+             <item>
+              <widget class="QLabel" name="labelAbouHwMemory">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="font">
+                <font>
+                 <pointsize>10</pointsize>
+                </font>
+               </property>
+               <property name="text">
+                <string>Device Memory:</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QLabel" name="labelAbouHwMemoryValue">
+               <property name="font">
+                <font>
+                 <pointsize>10</pointsize>
+                </font>
+               </property>
+               <property name="text">
+                <string/>
+               </property>
+              </widget>
+             </item>
+            </layout>
+           </item>
+          </layout>
          </widget>
         </item>
         <item>
@@ -2369,6 +2453,8 @@ QWidget {background-color: #EFEFEF;}</string>
   </customwidget>
  </customwidgets>
  <resources>
+  <include location="../img/images.qrc"/>
+  <include location="../img/images.qrc"/>
   <include location="../img/images.qrc"/>
  </resources>
  <connections/>


### PR DESCRIPTION
It allows to hide/show all labels with device information through changing visibility of widget. It also fix "%1" in device information labels at "About" page.

When you start gui application without an device connected, you can see this on "About" page:
![aboutpage](https://user-images.githubusercontent.com/7559412/29306314-7178cc0a-81b6-11e7-9d23-e6739e9496d8.png)
