### PR TITLE
Fixes

### DIFF
--- a/src/CredentialsManagement.cpp
+++ b/src/CredentialsManagement.cpp
@@ -135,6 +135,8 @@ void CredentialsManagement::enableCredentialsManagement(bool enable)
         ui->stackedWidget->setCurrentWidget(ui->pageUnlocked);
     else
         ui->stackedWidget->setCurrentWidget(ui->pageLocked);
+
+    ui->pageUnlocked->setFocus();
 }
 
 void CredentialsManagement::updateQuickAddCredentialsButtonState()

--- a/src/FilesCache.cpp
+++ b/src/FilesCache.cpp
@@ -107,6 +107,12 @@ bool FilesCache::setDbChangeNumber(quint8 changeNumber)
         return false;
 }
 
+bool FilesCache::exist()
+{
+    QFile cache_file(m_filePath);
+    return cache_file.exists();
+}
+
 bool FilesCache::setCardCPZ(QByteArray cardCPZ)
 {
     if (m_cardCPZ == cardCPZ)

--- a/src/FilesCache.h
+++ b/src/FilesCache.h
@@ -26,6 +26,7 @@ public slots:
     void resetState();
     bool setCardCPZ(QByteArray cardCPZ);
     bool setDbChangeNumber(quint8 changeNumber);
+    bool exist();
 private:
     QByteArray m_cardCPZ;
     QString m_filePath;

--- a/src/FilesManagement.cpp
+++ b/src/FilesManagement.cpp
@@ -115,6 +115,7 @@ FilesManagement::FilesManagement(QWidget *parent) :
     });
 
     ui->filesCacheListWidget->setVisible(false);
+    ui->emptyCacheLabel->setVisible(false);
 }
 
 FilesManagement::~FilesManagement()
@@ -237,7 +238,8 @@ void FilesManagement::loadFilesCacheModel()
     }
 
     listWidget->setVisible(listWidget->count() > 0);
-    ui->listFilesButton->setVisible(listWidget->count() <= 0);
+    ui->emptyCacheLabel->setVisible(listWidget->count() == 0);
+    ui->listFilesButton->setVisible(false);
 }
 
 void FilesManagement::currentSelectionChanged(const QModelIndex &curr, const QModelIndex &)

--- a/src/FilesManagement.ui
+++ b/src/FilesManagement.ui
@@ -205,6 +205,16 @@ border-right: none;
           <widget class="QListWidget" name="filesCacheListWidget"/>
          </item>
          <item>
+          <widget class="QLabel" name="emptyCacheLabel">
+           <property name="text">
+            <string>No Files In The Device</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+          </widget>
+         </item>
+         <item>
           <widget class="QPushButton" name="listFilesButton">
            <property name="minimumSize">
             <size>

--- a/src/MPDevice.cpp
+++ b/src/MPDevice.cpp
@@ -6354,6 +6354,11 @@ QStringList MPDevice::getFilesCache()
     return names;
 }
 
+bool MPDevice::hasFilesCache()
+{
+    return filesCache.exist();
+}
+
 void MPDevice::getStoredFiles(std::function<void (bool, QStringList)> cb)
 {
     /* New job for starting MMM */

--- a/src/MPDevice.h
+++ b/src/MPDevice.h
@@ -202,6 +202,7 @@ public:
     bool isFw12() { return isFw12Flag; }
 
     QStringList getFilesCache();
+    bool hasFilesCache();
     void getStoredFiles(std::function<void(bool success, QStringList filenames)> cb);
     void updateFilesCache();
     void addFileToCache(QString fileName);

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -346,6 +346,7 @@ MainWindow::MainWindow(WSClient *client, QWidget *parent) :
     connect(wsClient, &WSClient::lockUnlockModeChanged, [=]()
     {
         updateComboBoxIndex(ui->lockUnlockModeComboBox, wsClient->get_lockUnlockMode());
+        checkSettingsChanged();
     });
 
 

--- a/src/WSServerCon.cpp
+++ b/src/WSServerCon.cpp
@@ -867,6 +867,11 @@ void WSServerCon::sendDeviceUID()
 
 void WSServerCon::sendFilesCache()
 {
+    if (!mpdevice->hasFilesCache()) {
+        qDebug() << "There is fo files cache to send";
+        return;
+    }
+
     qDebug() << "Sending files cache";
     QJsonObject oroot = { {"msg", "files_cache_list"} };
     QJsonArray array;


### PR DESCRIPTION
For:
device settings tab: if we change the option selected for lock unlock feature and click save, the save & discard buttons do not disappear

credentials tab: when going into mmm, accepting the prompt on the mini & entering the pin, press the space bar: something odd will happen

Files Tab: when there are no files on the mini and clicking list files, the list files button is still there. We should instead remove that list files button and add a text "No Files In The Device"