### PR TITLE
Add hardening settings to systemd service

### DIFF
--- a/systemd/moolticuted.service
+++ b/systemd/moolticuted.service
@@ -2,10 +2,30 @@
 Description=Moolticute daemon
 
 [Service]
+Type=simple
 ExecStart=/usr/bin/moolticuted
 KillMode=process
 Restart=always
-Type=simple
+
+# Uncomment those fields and edit them to match your settings
+#User=nobody
+#Group=plugdev
+
+# Hardening for all
+CapabilityBoundingSet=
+RuntimeDirectory=moolticuted
+RuntimeDirectoryMode=750
+PrivateTmp=yes
+RemoveIPC=true
+ProtectSystem=strict
+ProtectHome=read-only
+MemoryDenyWriteExecute=true
+ProtectKernelModules=true
+ProtectKernelTunables=true
+ProtectControlGroups=true
+RestrictAddressFamilies=AF_INET AF_INET6 AF_NETLINK AF_UNIX
+RestrictNamespaces=true
+RestrictRealtime=true
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
This pull request adds a lot of hardening features to moolticuted systemd service.

The most important one is the execution as normal user instead of root. For this use, it requires good permissions defined on USB device (through given udev rule).

Others settings indicate unused features, to enforce their non-use in case of vulnerability.