### PR TITLE
Improve credentials changes management.

### DIFF
--- a/src/AnimatedColorButton.cpp
+++ b/src/AnimatedColorButton.cpp
@@ -55,8 +55,6 @@ int AnimatedColorButton::animationDuration() const
 
 void AnimatedColorButton::mousePressEvent(QMouseEvent *event)
 {
-    Q_UNUSED(event);
-
     QSettings s;
     bool enabled = s.value("settings/long_press_cancel", true).toBool();
 
@@ -65,6 +63,8 @@ void AnimatedColorButton::mousePressEvent(QMouseEvent *event)
     {
         m_tTimer.start();
         m_pAnimation->start();
+
+        emit pressed();
     }
     else if (!enabled)
     {

--- a/src/CredentialsManagement.h
+++ b/src/CredentialsManagement.h
@@ -55,7 +55,8 @@ private slots:
     void onCredentialUpdated(const QString &service, const QString &login, const QString &description, bool success);
     void saveSelectedCredential(const QModelIndex &proxyIndex=QModelIndex());
     void on_pushButtonEnterMMM_clicked();
-    void on_buttonDiscard_clicked();
+    void on_buttonDiscard_pressed();
+    void on_buttonDiscard_confirmed();
     void on_buttonSaveChanges_clicked();
     void requestPasswordForSelectedItem();
     void on_addCredentialButton_clicked();
@@ -90,6 +91,9 @@ private:
     bool deletingCred = false;
     QTimer m_tSelectLoginTimer;
     LoginItem *m_pAddedLoginItem;
+
+    QJsonArray m_loadedModelSerialiation;
+    bool m_selectionCanceled;
 
 signals:
     void wantEnterMemMode();


### PR DESCRIPTION
Fix for #116 
* Quick exit when "Discard all" clicked if no changes.
* Confirm current item changes if "Save all" clicked.
* Ask for confirmation on selected credential changed and select previus in case of cancelation.

